### PR TITLE
Add deviceId to Zaraz cookie

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,18 @@ const getUserId = (event: MCEvent) => {
   }
   return userId
 }
+
+// Get the device ID stored in the client, if it does not exist, make a random one, save it in the client, and return it.
+const getDeviceId = (event: MCEvent) => {
+  const { client } = event
+  let deviceId = event.payload.device_id || client.get('device_id')
+  if (!deviceId) {
+    deviceId = crypto.randomUUID()
+    client.set('device_id', deviceId, { scope: 'infinite' })
+  }
+  return deviceId
+}
+
 // Get the session ID stored in the client, if it does not exist, make a new one, save it in the client, and return it.
 
 const getSessionId = (event: MCEvent) => {
@@ -57,7 +69,7 @@ export default async function (manager: Manager, settings: ComponentSettings) {
       device_manufacturer: parsedUserAgent.device.vendor,
       device_model: parsedUserAgent.device.model,
       ...(payload.device_id && {
-        device_id: payload.device_id,
+        device_id: getDeviceId(event),
       }),
       ...(payload.app_version && {
         app_version: payload.app_version,


### PR DESCRIPTION
Based on [how Amplitude merges data](https://help.amplitude.com/hc/en-us/articles/115003135607-Track-unique-users), deviceID should be added to the cookie value to help with cross-domain tracking.

Don't fully know whether this is the right implementation, definitely open to edits.

In an ideal world, thinking the device_id would exist in the `cfz_amplitude` cookie just for having that info side by side with the user_id... but that may be naive.