### PR TITLE
Remove conditional object value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,9 +68,7 @@ export default async function (manager: Manager, settings: ComponentSettings) {
       os_version: parsedUserAgent.os.version,
       device_manufacturer: parsedUserAgent.device.vendor,
       device_model: parsedUserAgent.device.model,
-      ...(payload.device_id && {
-        device_id: getDeviceId(event),
-      }),
+      device_id: getDeviceId(event),
       ...(payload.app_version && {
         app_version: payload.app_version,
       }),


### PR DESCRIPTION
Follows up on a mistake in the implemenation for #9 ... we'll actually never reach the [`if` block](https://github.com/managed-components/amplitude/blob/main/src/index.ts#L19) to set the cookie since the function will [only fire if there is already a device_id](https://github.com/managed-components/amplitude/blob/main/src/index.ts#L71-L73).

Might be another way to address though